### PR TITLE
Fixed MaxListenersExceededWarning when creating many progress bars.

### DIFF
--- a/lib/multi-bar.js
+++ b/lib/multi-bar.js
@@ -34,10 +34,7 @@ module.exports = class MultiBar extends _EventEmitter{
         this.loggingBuffer = [];
 
         // add handler to restore cursor settings (stop the bar) on SIGINT/SIGTERM ?
-        if (this.options.gracefulExit){
-            process.once('SIGINT', this.stop.bind(this));
-            process.once('SIGTERM', this.stop.bind(this));
-        }
+        this.sigintCallback = this.stop.bind(this);
     }
 
     // add a new bar to the stack
@@ -67,6 +64,12 @@ module.exports = class MultiBar extends _EventEmitter{
     
             // initialize update timer
             this.timer = setTimeout(this.update.bind(this), this.schedulingRate);
+
+            // add handler to restore cursor settings (stop the bar) on SIGINT/SIGTERM ?
+            if (this.options.gracefulExit){
+                process.once('SIGINT', this.sigintCallback);
+                process.once('SIGTERM', this.sigintCallback);
+            }
         }
 
         // set flag
@@ -165,6 +168,12 @@ module.exports = class MultiBar extends _EventEmitter{
     }
 
     stop(){
+
+        // Remove event listeners
+        if (this.options.gracefulExit){
+            process.removeListener('SIGINT', this.sigintCallback);
+            process.removeListener('SIGTERM', this.sigintCallback);
+        }
 
         // stop timer
         clearTimeout(this.timer);

--- a/lib/single-bar.js
+++ b/lib/single-bar.js
@@ -19,10 +19,7 @@ module.exports = class SingleBar extends _GenericBar{
         this.schedulingRate = (this.terminal.isTTY() ? this.options.throttleTime : this.options.notTTYSchedule);
 
         // add handler to restore cursor settings (stop the bar) on SIGINT/SIGTERM ?
-        if (this.options.gracefulExit){
-            process.once('SIGINT', this.stop.bind(this));
-            process.once('SIGTERM', this.stop.bind(this));
-        }
+        this.sigintCallback = this.stop.bind(this);
     }
 
     // internal render function
@@ -68,6 +65,12 @@ module.exports = class SingleBar extends _GenericBar{
             return;
         }
 
+        // add handler to restore cursor settings (stop the bar) on SIGINT/SIGTERM ?
+        if (this.options.gracefulExit){
+            process.once('SIGINT', this.sigintCallback);
+            process.once('SIGTERM', this.sigintCallback);
+        }
+
         // save current cursor settings
         this.terminal.cursorSave();
 
@@ -90,6 +93,13 @@ module.exports = class SingleBar extends _GenericBar{
 
     // stop the bar
     stop(){
+
+        // Remove event listeners
+        if (this.options.gracefulExit){
+            process.removeListener('SIGINT', this.sigintCallback);
+            process.removeListener('SIGTERM', this.sigintCallback);
+        }
+
         // timer inactive ?
         if (!this.timer) {
             return;

--- a/lib/single-bar.js
+++ b/lib/single-bar.js
@@ -66,9 +66,11 @@ module.exports = class SingleBar extends _GenericBar{
         }
 
         // add handler to restore cursor settings (stop the bar) on SIGINT/SIGTERM ?
-        if (this.options.gracefulExit){
-            process.once('SIGINT', this.sigintCallback);
-            process.once('SIGTERM', this.sigintCallback);
+        if (!this.isActive){
+            if (this.options.gracefulExit){
+                process.once('SIGINT', this.sigintCallback);
+                process.once('SIGTERM', this.sigintCallback);
+            }
         }
 
         // save current cursor settings


### PR DESCRIPTION
When you create many progress bars (>10), eventually you will get `MaxListenersExceededWarning` since `SIGINT` and `SIGTERM` listeners keep getting added in the constructor but are never removed. I fixed it by adding them on `start()`/`create()` and removing them on `stop()`