### PR TITLE
allow individual styling in `multiBar.create()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules*
 intern_*
 dev.js
 yarn-error.log
+.yarn
+.pnp.*

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ const <instance> = new cliProgress.MultiBar(options:object [, preset:object]);
 
 Adds a new progress bar to the container and starts the bar. Returns regular `SingleBar` object which can be individually controlled.
 
-Additional `barOptions` can be passed directly to the [generic-bar](lib/generic-bar.js) to override the global options for a single bar instance. This can be useful to change the appearance of a single bar object. But be patient: this should only be used to override formats - DON'T try to set other global options like the terminal, synchronous flags, etc..
+Additional `barOptions` can be passed directly to the [generic-bar](lib/generic-bar.js) to override the global options for a single bar instance. This can be useful to change the appearance of a single bar object. But be patient: this should only be used to override format\barChars  - DON'T try to set other global options like the terminal, synchronous flags, etc..
 
 ```js
 const <barInstance> = <instance>.create(totalValue:int, startValue:int [, payload:object = {} [, barOptions:object = {}]]);

--- a/lib/generic-bar.js
+++ b/lib/generic-bar.js
@@ -45,6 +45,14 @@ module.exports = class GenericBar extends _EventEmitter{
         // progress bar active ?
         this.isActive = false;
 
+        // if barCompleteChar/barIncompleteChar was provided, re-cache it
+        if (options.barCompleteString[1] !== options.barCompleteChar) {
+            options.barCompleteString = options.barCompleteChar.repeat(options.barsize);
+        }
+        if (options.barIncompleteString[1] !== options.barIncompleteChar) {
+            options.barIncompleteString = options.barIncompleteChar.repeat(options.barsize);
+        }
+
         // use default formatter or custom one ?
         this.formatter = (typeof this.options.format === 'function') ? this.options.format : _formatter;
     }

--- a/lib/options.js
+++ b/lib/options.js
@@ -44,9 +44,12 @@ module.exports = {
         // disable linewrapping ?
         options.linewrap = mergeOption(opt.linewrap, false);
 
+        options.barCompleteChar = mergeOption(opt.barCompleteChar, '=');
+        options.barIncompleteChar = mergeOption(opt.barIncompleteChar, '-');
+
         // pre-render bar strings (performance)
-        options.barCompleteString = (new Array(options.barsize + 1 ).join(opt.barCompleteChar || '='));
-        options.barIncompleteString = (new Array(options.barsize + 1 ).join(opt.barIncompleteChar || '-'));
+        options.barCompleteString = options.barCompleteChar.repeat(options.barsize);
+        options.barIncompleteString = options.barIncompleteChar.repeat(options.barsize);
 
         // glue sequence (control chars) between bar elements ?
         options.barGlue = mergeOption(opt.barGlue, '');


### PR DESCRIPTION
on `multiBar.create()`, allow changing the following style options:
* `barCompleteChar`
* `barIncompleteChar`

Because I just wanted to have a top bar that is a general status, and the other ones are the running processes

![gif](https://user-images.githubusercontent.com/78568641/219906341-96c95243-ab32-4776-8bc3-392d141ca92f.gif)
