### PR TITLE
fix linewrap option for WriteStream

### DIFF
--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -134,12 +134,13 @@ class Terminal{
 
     // control line wrapping
     lineWrapping(enabled){
+        // store state
+        this.linewrap = enabled;
+
         if (!this.stream.isTTY){
             return;
         }
 
-        // store state
-        this.linewrap = enabled;
         if (enabled){
             this.stream.write('\x1B[?7h');
         }else{


### PR DESCRIPTION
fix linewrap option for WriteStream

when you send `linewrap = fasle` and use WriteStream for output it cut text to 200

