### PR TITLE
Support ETAs > 100 hours

### DIFF
--- a/lib/format-time.js
+++ b/lib/format-time.js
@@ -15,8 +15,12 @@ module.exports = function formatTime(t, options, roundToMultipleOf){
         return (options.autopaddingChar + v).slice(-2);
     }
 
+    // > 1d ?
+    if(t > 3600 * 24) {
+        return Math.floor(t / 3600 / 24) + 'd' + autopadding(round((t % (3600 * 24)) / 3600)) + 'h';
+
     // > 1h ?
-    if (t > 3600) {
+    } else if (t > 3600) {
         return autopadding(Math.floor(t / 3600)) + 'h' + autopadding(round((t % 3600) / 60)) + 'm';
 
     // > 60s ?


### PR DESCRIPTION
This will allow ETAs to be displayed correctly regardless of how long they are. If the ETA is longer than 1 day it will display as:
1d20h or 25048d03h.

This addresses issue #152.