### PR TITLE
Refactor string-width import for Bun compatibility

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,7 +1,13 @@
-const _stringWidth = require('string-width');
 const _defaultFormatValue = require('./format-value');
 const _defaultFormatBar = require('./format-bar');
 const _defaultFormatTime = require('./format-time');
+let _stringWidth;
+
+if (typeof Bun !== 'undefined') {
+    _stringWidth = Bun.stringWidth;
+} else {
+    _stringWidth = require('string-width');
+}
 
 // generic formatter
 module.exports = function defaultFormatter(options, params, payload){


### PR DESCRIPTION
If in a Bun runtime, use [Buns string-width util](https://bun.com/docs/api/utils#bun-stringwidth-6-756x-faster-string-width-alternative), it's ~6,756x faster than the NPM package.